### PR TITLE
[FEAT] 유저 회원가입 이메일 인증 및 중복 인증 request 방지 구현하기

### DIFF
--- a/user-service/src/main/java/com/example/userservice/user/controller/UserCreateController.java
+++ b/user-service/src/main/java/com/example/userservice/user/controller/UserCreateController.java
@@ -6,14 +6,12 @@ import com.example.userservice.user.domain.join.JoinUserCertification;
 import com.example.userservice.user.domain.join.JoinUserCreate;
 import com.example.userservice.user.domain.join.JoinUser;
 import com.example.userservice.user.domain.user.UserStatus;
+import com.example.userservice.util.certification.email.EmailCertification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -22,10 +20,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserCreateController {
 
     private final JoinUserService joinUserService;
-
+    private final EmailCertification emailCertification;
     // user Create
     @PostMapping
     public ResponseEntity<UserJoinResponse> create(@RequestBody JoinUserCreate userCreate) {
+        if (!emailCertification.verify(userCreate.getSchool(), userCreate.getEmail())) {
+            JoinUser joinUser = JoinUser.builder().email(userCreate.getEmail()).school(userCreate.getSchool())
+                    .status(UserStatus.BANNED).build();
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(UserJoinResponse.from(joinUser));
+        }
         JoinUser joinUser = joinUserService.join(userCreate);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
@@ -33,13 +38,26 @@ public class UserCreateController {
     }
 
     // verify certification code after user create
+    // 방식 1 번호 입력
     @PostMapping("/certification")
-    public ResponseEntity<UserJoinResponse> certification(
+    public ResponseEntity<UserJoinResponse> certificationByCode(
             @RequestBody JoinUserCertification joinUserCertification
     ){
         JoinUser joinUser = joinUserService.certification(joinUserCertification);
         return ResponseEntity.status(HttpStatus.OK).body(UserJoinResponse.from(joinUser));
     }
+
+    // 방식 2 링크
+    // String으로 인증 정보 반환 : 수정 가능
+    @GetMapping("/{email}/verify")
+    public JoinUser certificationByLink(
+            @PathVariable String email,
+            @RequestParam String certificationCode
+    ){
+        JoinUserCertification joinUserCertification = JoinUserCertification.from(email, certificationCode);
+        return joinUserService.certification(joinUserCertification);
+    }
+
 
     // 회원 가입
 

--- a/user-service/src/main/java/com/example/userservice/user/controller/response/UserJoinResponse.java
+++ b/user-service/src/main/java/com/example/userservice/user/controller/response/UserJoinResponse.java
@@ -22,4 +22,6 @@ public class UserJoinResponse {
                 .build();
     }
 
+
+
 }

--- a/user-service/src/main/java/com/example/userservice/user/domain/User.java
+++ b/user-service/src/main/java/com/example/userservice/user/domain/User.java
@@ -22,8 +22,6 @@ public class User {
     private final LocalDateTime createdAt;
 
 
-
-
     //User Builder
     @Builder
     public User(String id, String pw, String email, School school, UserDegree degree, UserSex sex, UserMajor major, String nickname, UserStatus status, LocalDateTime createdAt) {

--- a/user-service/src/main/java/com/example/userservice/user/domain/join/JoinUser.java
+++ b/user-service/src/main/java/com/example/userservice/user/domain/join/JoinUser.java
@@ -38,4 +38,13 @@ public class JoinUser {
                 .build();
     }
 
+    public JoinUser updateStatus(JoinUser joinUser, UserStatus status) {
+        return JoinUser.builder()
+                .email(joinUser.getEmail())
+                .school(joinUser.getSchool())
+                .status(status)
+                .certificationCode(joinUser.getCertificationCode())
+                .build();
+    }
+
 }

--- a/user-service/src/main/java/com/example/userservice/user/domain/join/JoinUserCertification.java
+++ b/user-service/src/main/java/com/example/userservice/user/domain/join/JoinUserCertification.java
@@ -19,4 +19,11 @@ public class JoinUserCertification {
         this.email = email;
         this.certificationCode = certificationCode;
     }
+
+    public static JoinUserCertification from(String email, String certificationCode) {
+        return JoinUserCertification.builder()
+                .email(email)
+                .certificationCode(certificationCode)
+                .build();
+    }
 }

--- a/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserConcurrentMapRepository.java
+++ b/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserConcurrentMapRepository.java
@@ -17,6 +17,11 @@ public class JoinUserConcurrentMapRepository implements JoinUserRepository {
     }
 
     @Override
+    public boolean obtain(String email) {
+        return mapRepository.containsKey(email);
+    }
+
+    @Override
     public JoinUser findByEmail(String email) {
         return mapRepository.get(email);
     }

--- a/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserConcurrentMapRepository.java
+++ b/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserConcurrentMapRepository.java
@@ -17,6 +17,11 @@ public class JoinUserConcurrentMapRepository implements JoinUserRepository {
     }
 
     @Override
+    public JoinUser replace(String email, JoinUser newJoinUser) {
+        return mapRepository.replace(email, newJoinUser);
+    }
+
+    @Override
     public boolean obtain(String email) {
         return mapRepository.containsKey(email);
     }

--- a/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserRepository.java
+++ b/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserRepository.java
@@ -6,4 +6,6 @@ public interface JoinUserRepository {
     JoinUser findByEmail(String email);
 
     JoinUser save(JoinUser joinUser);
+
+    boolean obtain(String email);
 }

--- a/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserRepository.java
+++ b/user-service/src/main/java/com/example/userservice/user/infrastructure/join/JoinUserRepository.java
@@ -8,4 +8,6 @@ public interface JoinUserRepository {
     JoinUser save(JoinUser joinUser);
 
     boolean obtain(String email);
+
+    JoinUser replace(String email, JoinUser newJoinUser);
 }

--- a/user-service/src/main/java/com/example/userservice/user/service/CertificationService.java
+++ b/user-service/src/main/java/com/example/userservice/user/service/CertificationService.java
@@ -1,5 +1,6 @@
 package com.example.userservice.user.service;
 
+import com.example.userservice.user.domain.user.School;
 import com.example.userservice.user.service.port.MailSender;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +13,12 @@ public class CertificationService {
 
     private final MailSender mailSender;
 
-    private final String title = "Please certify your email address";
-    private final String content = "Please click the following link to certify your email address: ";
+    private final static String TITLE = "Please certify your email address";
+    private final static String CONTENT = "Please click the following link to certify your email address: ";
 
     public void send(String email, String certificationCode) {
         String certificationUrl = generateCertificationUrl(email, certificationCode);
-        mailSender.send(email, title, content + certificationCode);
+        mailSender.send(email, TITLE, CONTENT + certificationUrl);
     }
 
     private String generateCertificationUrl(String email, String certificationCode) {

--- a/user-service/src/main/java/com/example/userservice/user/service/JoinUserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/user/service/JoinUserServiceImpl.java
@@ -10,8 +10,12 @@ import com.example.userservice.user.domain.join.JoinUser;
 import com.example.userservice.user.infrastructure.join.JoinUserRepository;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
+@Slf4j
 @Builder
 @Service
 @RequiredArgsConstructor
@@ -25,7 +29,14 @@ public class JoinUserServiceImpl implements JoinUserService {
     @Override
     public JoinUser join(JoinUserCreate userCreate) {
         JoinUser joinUser = JoinUser.from(userCreate, certificationHolder);
-        System.out.println("joinUser = " + joinUser);
+
+        // 이메일과 학교 정보 대조
+        
+        // 이미 인증을 시도한 이메일인지 확인
+        if(joinUserRepository.obtain(joinUser.getEmail())){
+            certificationService.send(joinUser.getEmail(), joinUser.getCertificationCode());
+            return joinUser;
+        }
 
         joinUser = joinUserRepository.save(joinUser);
         certificationService.send(joinUser.getEmail(), joinUser.getCertificationCode());

--- a/user-service/src/main/java/com/example/userservice/user/service/JoinUserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/user/service/JoinUserServiceImpl.java
@@ -8,12 +8,11 @@ import com.example.userservice.user.controller.port.JoinUserService;
 import com.example.userservice.user.domain.join.JoinUserCreate;
 import com.example.userservice.user.domain.join.JoinUser;
 import com.example.userservice.user.infrastructure.join.JoinUserRepository;
+import com.example.userservice.util.certification.email.EmailCertification;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Slf4j
 @Builder
@@ -24,19 +23,19 @@ public class JoinUserServiceImpl implements JoinUserService {
     private final CertificationHolder certificationHolder;
     private final JoinUserRepository joinUserRepository;
     private final CertificationService certificationService;
-
+    private final EmailCertification emailCertification;
 
     @Override
     public JoinUser join(JoinUserCreate userCreate) {
-        JoinUser joinUser = JoinUser.from(userCreate, certificationHolder);
 
-        // 이메일과 학교 정보 대조
-        
         // 이미 인증을 시도한 이메일인지 확인
-        if(joinUserRepository.obtain(joinUser.getEmail())){
-            certificationService.send(joinUser.getEmail(), joinUser.getCertificationCode());
-            return joinUser;
+        if(joinUserRepository.obtain(userCreate.getEmail())){
+            JoinUser duplicateUser = joinUserRepository.findByEmail(userCreate.getEmail());
+            certificationService.send(duplicateUser.getEmail(), duplicateUser.getCertificationCode());
+            return duplicateUser;
         }
+        // 중복 유저가 아니라면 보안코드 생성
+        JoinUser joinUser = JoinUser.from(userCreate, certificationHolder);
 
         joinUser = joinUserRepository.save(joinUser);
         certificationService.send(joinUser.getEmail(), joinUser.getCertificationCode());
@@ -46,15 +45,12 @@ public class JoinUserServiceImpl implements JoinUserService {
     @Override
     public JoinUser certification(JoinUserCertification joinUserCertification) {
         JoinUser joinUser = joinUserRepository.findByEmail(joinUserCertification.getEmail());
+        // 보안코드가 맞는지 확인
         boolean compareResult = compare(joinUser.getCertificationCode(), joinUserCertification.getCertificationCode());
-
         if (compareResult) {
-            return joinUser.builder()
-                    .email(joinUser.getEmail())
-                    .school(joinUser.getSchool())
-                    .certificationCode((joinUserCertification.getCertificationCode()))
-                    .status(UserStatus.ABLE)
-                    .build();
+            joinUser = joinUser.updateStatus(joinUser, UserStatus.ABLE);
+            joinUserRepository.replace(joinUser.getEmail(), joinUser);
+            return joinUser;
         }
         return joinUser;
     }

--- a/user-service/src/main/java/com/example/userservice/util/certification/email/EmailCertification.java
+++ b/user-service/src/main/java/com/example/userservice/util/certification/email/EmailCertification.java
@@ -1,0 +1,47 @@
+package com.example.userservice.util.certification.email;
+
+import com.example.userservice.user.domain.user.School;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+@Component
+public class EmailCertification {
+
+    private HashMap<School, ArrayList<String>> emailCertificationMap = new HashMap<>();
+
+    public EmailCertification() {
+        ArrayList<String> eamilCertificateStringsOfKAIST = new ArrayList<>();
+        eamilCertificateStringsOfKAIST.add("kaist.ac.kr");
+        emailCertificationMap.put(School.KAIST, eamilCertificateStringsOfKAIST);
+
+        ArrayList<String> eamilCertificateStringsOfGIST = new ArrayList<>();
+        eamilCertificateStringsOfGIST.add("gist.ac.kr");
+        eamilCertificateStringsOfGIST.add("gm.gist.ac.kr");
+        emailCertificationMap.put(School.GIST, eamilCertificateStringsOfGIST);
+
+        ArrayList<String> eamilCertificateStringsOfDGIST = new ArrayList<>();
+        eamilCertificateStringsOfDGIST.add("dgist.ac.kr");
+        emailCertificationMap.put(School.DGIST, eamilCertificateStringsOfDGIST);
+
+        ArrayList<String> eamilCertificateStringsOfUnist = new ArrayList<>();
+        eamilCertificateStringsOfUnist.add("unist.ac.kr");
+        emailCertificationMap.put(School.UNIST, eamilCertificateStringsOfUnist);
+
+        ArrayList<String> eamilCertificateStringsOfKentech = new ArrayList<>();
+        eamilCertificateStringsOfKentech.add("kentech.ac.kr");
+        emailCertificationMap.put(School.KENTECH, eamilCertificateStringsOfKentech);
+    }
+
+    public boolean verify(School school, String email) {
+        String schoolEmailString = (email.split("@"))[1];
+        for(String emailCertification : emailCertificationMap.get(school)){
+            if (emailCertification.equals(schoolEmailString)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
## 🐼 Summary (요약)

1. 유저 회원가입 이메일 인증 및 중복 인증 request 방지를 구현하였습니다. 
2. 유저 회원가입 인증 방식을 6자리 코드 인증, 링크 인증 두개로 구현하였습니다.

## 😼 Describe changes with intention (변경내용)

- frontend의 구현 방식에 맞게 유저 이메일을 인증할 수 있도록 방식을 분기하였습니다.
- userStatus를 도입하여 중복 email 인증을 방지하였습니다.
- 각 학교의 email의 도메인에 맞는지 email검사 코드를 추가하였습니다.

## 🐶 Link Issue number (참고사항)

- close #31 
