### PR TITLE
[FEAT] 유저 서비스 Success/Exception 핸들링 구현 완료

### DIFF
--- a/user-service/src/main/java/com/example/userservice/user/controller/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/example/userservice/user/controller/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.example.userservice.user.controller;
+
+import com.example.userservice.user.controller.response.GlobalResponse;
+import com.example.userservice.user.controller.response.code.ErrorCode;
+import com.example.userservice.user.error.GlobalException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<GlobalResponse> handleGlobalException(GlobalException ex) {
+        return GlobalResponse.of(ex);
+    }
+}

--- a/user-service/src/main/java/com/example/userservice/user/controller/response/GlobalResponse.java
+++ b/user-service/src/main/java/com/example/userservice/user/controller/response/GlobalResponse.java
@@ -1,0 +1,45 @@
+package com.example.userservice.user.controller.response;
+
+import com.example.userservice.user.controller.response.code.ErrorCode;
+import com.example.userservice.user.controller.response.code.SuccessCode;
+import com.example.userservice.user.error.GlobalException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor @RequiredArgsConstructor
+public class GlobalResponse<T> {
+
+    private final int status;
+    private final String message;
+    private T data;
+
+    public static ResponseEntity<GlobalResponse> of(SuccessCode successCode) {
+        return ResponseEntity.status(successCode.getStatus())
+                .body(new GlobalResponse(successCode.getStatusCode(), successCode.getMessage()));
+    }
+
+    public static <T> ResponseEntity<GlobalResponse<T>> of(SuccessCode successCode, T data) {
+        return ResponseEntity.status(successCode.getStatus())
+                .body(new GlobalResponse<T>(successCode.getStatusCode(), successCode.getMessage(), data));
+    }
+
+    public static <T> ResponseEntity<GlobalResponse<T>> of(SuccessCode successCode, T data, HttpHeaders headers) {
+        return ResponseEntity.status(successCode.getStatus())
+                .headers(headers)
+                .body(new GlobalResponse<T>(successCode.getStatusCode(), successCode.getMessage(), data));
+    }
+
+    public static ResponseEntity<GlobalResponse> of(GlobalException exception) {
+        return ResponseEntity.status(exception.getErrorCode().getStatus())
+                .body(new GlobalResponse(exception.getErrorCode().getStatusCode(), exception.getErrorCode().getMessage()));
+    }
+
+    public static <T> ResponseEntity<GlobalResponse<T>> of(ErrorCode errorCode, T data) {
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(new GlobalResponse<T>(errorCode.getStatusCode(), errorCode.getMessage(), data));
+    }
+}

--- a/user-service/src/main/java/com/example/userservice/user/controller/response/code/ErrorCode.java
+++ b/user-service/src/main/java/com/example/userservice/user/controller/response/code/ErrorCode.java
@@ -1,0 +1,40 @@
+package com.example.userservice.user.controller.response.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // 500 서버 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // 회원 C, R, U, D 실패
+    USER_CREATE_ERROR(HttpStatus.FORBIDDEN, "유저 생성에 실패하였습니다"),
+    USER_DUPLICATE_ERROR(HttpStatus.CONFLICT, "이미 존재하는 유저입니다."),
+    USER_INVALID_ERROR(HttpStatus.UNAUTHORIZED, "확인되지 않은 이메일입니다."),
+    USER_EMAIL_CHECK_FAIL(HttpStatus.FORBIDDEN, "이메일과 학교 정보가 유효하지 않습니다."),
+    WRONG_USER_PASSWORD(HttpStatus.FORBIDDEN, "아이디나 비밀번호가 잘못되었습니다."),
+
+    USER_NOT_FOUND_ID(HttpStatus.NOT_FOUND, "해당 id의 유저가 없습니다."),
+    USER_NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "해당 eamil의 유저가 없습니다."),
+    USER_UPDATE_ERROR(HttpStatus.FORBIDDEN, "유저 업데이트에 실패하였습니다."),
+    USER_DELETE_ERROR(HttpStatus.FORBIDDEN, "유저 삭제에 실패했습니다."),
+    // 권한 문제
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "작업을 수행 할 권한이 없습니다."),
+
+    // 로그인 실패
+    LOGIN_ERROR(HttpStatus.FORBIDDEN, "로그인에 실패하였습니다."),
+
+    // request error
+    INVALID_REQUEST(HttpStatus.FORBIDDEN, "잘못된 입력입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    public int getStatusCode() {
+        return status.value();
+    }
+}

--- a/user-service/src/main/java/com/example/userservice/user/controller/response/code/SuccessCode.java
+++ b/user-service/src/main/java/com/example/userservice/user/controller/response/code/SuccessCode.java
@@ -1,0 +1,33 @@
+package com.example.userservice.user.controller.response.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum SuccessCode {
+    // 200 OK - 기본, 유저 조회/삭제/업데이트
+    OK(HttpStatus.OK, "요청이 성공했습니다."),
+
+    // 유저 R,U,D
+    VALUE_OK(HttpStatus.OK, "조회에 성공했습니다."),
+    DELETE_OK(HttpStatus.OK, "삭제에 성공했습니다."),
+    UPDATE_OK(HttpStatus.OK, "유저 업데이트에 성공했습니다."),
+
+    // 회원가입
+    EMAIL_OK(HttpStatus.OK, "이메일 요청에 성공했습니다."),
+    EMAIL_CREATED(HttpStatus.CREATED, "이메일을 통한 인증코드 생성에 성공했습니다."),
+    EMAIL_VERIFIED(HttpStatus.OK, "이메일 인증에 성공했습니다."),
+    USER_CREATED(HttpStatus.CREATED, "유저 생성에 성공했습니다."),
+
+    // 로그인
+    LOGIN_OK(HttpStatus.OK, "로그인에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    public int getStatusCode() {
+        return status.value();
+    }
+}

--- a/user-service/src/main/java/com/example/userservice/user/error/GlobalException.java
+++ b/user-service/src/main/java/com/example/userservice/user/error/GlobalException.java
@@ -1,0 +1,14 @@
+package com.example.userservice.user.error;
+
+import com.example.userservice.user.controller.response.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException{
+    private ErrorCode errorCode;
+
+    public GlobalException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/user-service/src/main/java/com/example/userservice/user/service/JoinUserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/user/service/JoinUserServiceImpl.java
@@ -1,6 +1,5 @@
 package com.example.userservice.user.service;
 
-import com.example.userservice.user.domain.User;
 import com.example.userservice.user.domain.join.JoinUserCertification;
 import com.example.userservice.user.domain.user.UserStatus;
 import com.example.userservice.user.service.port.UserRepository;
@@ -31,12 +30,7 @@ public class JoinUserServiceImpl implements JoinUserService {
     @Override
     public boolean checkEmailBeforeCertification(String email) {
 
-        if (joinUserRepository.obtain(email)) {
-            return false;
-        }
-        if(userRepository.findByEmail(email).isPresent()){
-            return false;
-        }
+        if ((joinUserRepository.obtain(email)) || (userRepository.findByEmail(email).isPresent())) return false;
         return true;
     }
 

--- a/user-service/src/main/java/com/example/userservice/util/certification/email/EmailCertification.java
+++ b/user-service/src/main/java/com/example/userservice/util/certification/email/EmailCertification.java
@@ -1,6 +1,8 @@
 package com.example.userservice.util.certification.email;
 
+import com.example.userservice.user.controller.response.code.ErrorCode;
 import com.example.userservice.user.domain.user.School;
+import com.example.userservice.user.error.GlobalException;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -34,14 +36,14 @@ public class EmailCertification {
         emailCertificationMap.put(School.KENTECH, eamilCertificateStringsOfKentech);
     }
 
-    public boolean verify(School school, String email) {
+    public String verify(School school, String email) {
         String schoolEmailString = (email.split("@"))[1];
         for(String emailCertification : emailCertificationMap.get(school)){
             if (emailCertification.equals(schoolEmailString)) {
-                return true;
+                return email;
             }
         }
-        return false;
+        throw new GlobalException(ErrorCode.USER_EMAIL_CHECK_FAIL);
     }
 
 }


### PR DESCRIPTION
## 🐼 Summary (요약)

유저 서비스 Success/Exception 핸들링 구현 완료

## 😼 Describe changes with intention (변경내용)

- Error, Success에 해당하는 사항들을 enum으로 만들었습니다.
- Global Response를 만들어 success, fail 모두 이 response를 통하여 user에게 전달되도록 하였습니다.

## 🐶 Link Issue number (참고사항)

- close #52 
- 매번 최고의 커밋을 하고 싶은데 맘처럼 안되네요. 대신에 최선의 고민은 꾸준히 하겠습니다 ^_^

