### PR TITLE
[FIX] User certification 5자리 오류 해결

### DIFF
--- a/user-service/src/main/java/com/example/userservice/user/dto/request/UserLoginRequest.java
+++ b/user-service/src/main/java/com/example/userservice/user/dto/request/UserLoginRequest.java
@@ -1,10 +1,12 @@
 package com.example.userservice.user.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class UserLoginRequest {
 
     private String email;

--- a/user-service/src/main/java/com/example/userservice/user/service/UserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/user/service/UserServiceImpl.java
@@ -16,6 +16,7 @@ import com.example.userservice.user.service.port.JwtTokenService;
 import com.example.userservice.user.service.port.UserRepository;
 import com.example.userservice.util.clock.ClockHolder;
 import com.example.userservice.util.id.IdGenerator;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@Builder
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
@@ -74,7 +76,7 @@ public class UserServiceImpl implements UserService {
         User user = findByEmail(userUpdate.getEmail());
 
         User updatedUser = User.fromWithUserUpdate(user, userUpdate);
-        updatedUser = user.encodePw(user, passwordEncoder.encode(updatedUser.getPassword()));
+        updatedUser = User.encodePw(updatedUser, passwordEncoder.encode(updatedUser.getPassword()));
         if (updatedUser == null) {
             throw new GlobalException(ErrorCode.USER_UPDATE_ERROR);
         }

--- a/user-service/src/main/java/com/example/userservice/util/certification/CertificationDigitHolder.java
+++ b/user-service/src/main/java/com/example/userservice/util/certification/CertificationDigitHolder.java
@@ -1,13 +1,17 @@
 package com.example.userservice.util.certification;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class CertificationDigitHolder implements CertificationHolder{
     @Override
     public String random() {
         java.util.Random generator = new java.util.Random();
         generator.setSeed(System.currentTimeMillis());
-        return Integer.toString(generator.nextInt(1000000) % 1000000);
+
+        int num = generator.nextInt(100000000) ;
+        return String.valueOf(num).substring(0,6);
     }
 }

--- a/user-service/src/test/java/com/example/userservice/user/mock/FakeUserRepository.java
+++ b/user-service/src/test/java/com/example/userservice/user/mock/FakeUserRepository.java
@@ -6,6 +6,7 @@ import com.example.userservice.user.service.port.UserRepository;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -36,7 +37,9 @@ public class FakeUserRepository implements UserRepository {
 
     @Override
     public User update(User user) {
-        return userMap.replace(UserEntity.from(user).getEmail(), UserEntity.from(user)).toModel();
+        userMap.remove(user.getEmail());
+        userMap.put(user.getEmail(), UserEntity.from(user));
+        return userMap.get(user.getEmail()).toModel();
     }
 
     @Override

--- a/user-service/src/test/java/com/example/userservice/user/service/UserServiceImplTest.java
+++ b/user-service/src/test/java/com/example/userservice/user/service/UserServiceImplTest.java
@@ -1,0 +1,191 @@
+package com.example.userservice.user.service;
+
+import com.example.userservice.user.domain.User;
+import com.example.userservice.user.domain.UserUpdate;
+import com.example.userservice.user.domain.create.UserCreate;
+import com.example.userservice.user.domain.join.JoinUser;
+import com.example.userservice.user.domain.token.Token;
+import com.example.userservice.user.domain.token.UserWithToken;
+import com.example.userservice.user.domain.user.*;
+import com.example.userservice.user.dto.request.UserDeleteRequest;
+import com.example.userservice.user.dto.request.UserLoginRequest;
+import com.example.userservice.user.infrastructure.join.JoinUserRepository;
+import com.example.userservice.user.mock.FakeUserDigitRepository;
+import com.example.userservice.user.mock.FakeUserRepository;
+import com.example.userservice.user.service.auth.JwtTokenServiceImpl;
+import com.example.userservice.user.service.port.UserRepository;
+import com.example.userservice.util.clock.ClockHolder;
+import com.example.userservice.util.clock.SystemClockHolder;
+import com.example.userservice.util.id.IdGenerator;
+import com.example.userservice.util.id.IdGeneratorByUUID;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    private UserServiceImpl userService;
+
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtTokenServiceImpl jwtTokenService;
+    @Mock
+    private JoinUserServiceImpl joinUserService;
+    @Spy
+    private PasswordEncoder passwordEncoder;
+
+    private final String newDummyPassword = "new";
+    private final String oldDummyPassword = "old";
+    private final String email = "test@test.com";
+
+
+    @BeforeEach
+    void init() {
+        ClockHolder clockHolder = new SystemClockHolder();
+        IdGenerator idGenerator = new IdGeneratorByUUID();
+        JoinUserRepository joinUserRepository = new FakeUserDigitRepository();
+
+        userRepository = new FakeUserRepository();
+
+        PasswordEncoder spyPasswordEncoder = new BCryptPasswordEncoder();
+        passwordEncoder = spy(spyPasswordEncoder);
+
+        doReturn(newDummyPassword).when(passwordEncoder).encode(any(String.class));
+
+        userService = UserServiceImpl.builder()
+                .clockHolder(clockHolder)
+                .userRepository(userRepository)
+                .jwtTokenService(jwtTokenService)
+                .passwordEncoder(passwordEncoder)
+                .idGenerator(idGenerator)
+                .joinUserService(joinUserService)
+                .joinUserRepository(joinUserRepository)
+                .build();
+
+        JoinUser joinUser = JoinUser.builder()
+                .email(email)
+                .school(School.GIST)
+                .status(UserStatus.ABLE)
+                .build();
+        doReturn(joinUser).when(joinUserService).emailCertificationBeforeJoin("test@test.com");
+
+        UserCreate create = UserCreate.builder()
+                .pw(oldDummyPassword)
+                .email("test@test.com")
+                .degree(UserDegree.Master)
+                .sex(UserSex.FEMALE)
+                .major(UserMajor.AI)
+                .nickname("dummy")
+                .build();
+
+        userService.create(create);
+    }
+
+    @Test
+    @DisplayName("유저를 생성한다.")
+    void 유저를_생성한다() {
+
+        JoinUser joinUser = JoinUser.builder()
+                .email("test11@test.com")
+                .school(School.GIST)
+                .status(UserStatus.ABLE)
+                .build();
+        doReturn(joinUser).when(joinUserService).emailCertificationBeforeJoin(any(String.class));
+
+        UserCreate create = UserCreate.builder()
+                .pw(oldDummyPassword)
+                .email("test11@test.com")
+                .degree(UserDegree.Master)
+                .sex(UserSex.FEMALE)
+                .major(UserMajor.AI)
+                .nickname("dummy")
+                .build();
+
+        User user = userService.create(create);
+        User userFind = userRepository.findById(user.getId()).orElseThrow();
+
+        Assertions.assertThat(user.getEmail()).isEqualTo(create.getEmail());
+        Assertions.assertThat(user.getSchool()).isEqualTo(joinUser.getSchool());
+        Assertions.assertThat(user.getPassword()).isEqualTo(newDummyPassword);
+        Assertions.assertThat(user.getCreatedAt()).isInstanceOf(Long.class);
+
+        // 저장되는지
+        Assertions.assertThat(user.getId()).isEqualTo(userFind.getId());
+    }
+
+    @Test
+    @DisplayName("유저 로그인")
+    void 유저_로그인() {
+        doReturn(true).when(passwordEncoder).matches(any(String.class), any(String.class));
+
+        UserLoginRequest userLoginRequest = new UserLoginRequest(
+                "test@test.com", newDummyPassword
+        );
+        when(jwtTokenService.accessToken(any(User.class))).thenReturn("test access token");
+        when(jwtTokenService.refreshToken(any(User.class))).thenReturn(Token.builder().refreshToken("test refresh token").build());
+
+        UserWithToken userWithToken = userService.login(userLoginRequest);
+
+        Assertions.assertThat(userWithToken.getUser().getEmail()).isEqualTo(userLoginRequest.getEmail());
+        Assertions.assertThat(userWithToken.getAccess()).isInstanceOf(String.class);
+        Assertions.assertThat(userWithToken.getRefresh()).isInstanceOf(String.class);
+    }
+
+    // 업데이트
+    @Test
+    @DisplayName("유저 업데이트를 진행한다.")
+    void 유저_업데이트() {
+        UserUpdate userUpdate = UserUpdate.builder()
+                .email(email)
+                .password(newDummyPassword)
+                .school(School.KAIST)
+                .degree(UserDegree.Doctor)
+                .sex(UserSex.MALE)
+                .major(UserMajor.ChemiStry)
+                .nickname("New dummy")
+                .build();
+
+        userService.update(userUpdate);
+
+        User user = userRepository.findByEmail(userUpdate.getEmail()).orElseThrow();
+        Assertions.assertThat(user.getEmail()).isEqualTo(userUpdate.getEmail());
+        Assertions.assertThat(user.getSchool()).isEqualTo(userUpdate.getSchool());
+        Assertions.assertThat(user.getDegree()).isEqualTo(userUpdate.getDegree());
+        Assertions.assertThat(user.getMajor()).isEqualTo(userUpdate.getMajor());
+        Assertions.assertThat(user.getNickname()).isEqualTo(userUpdate.getNickname());
+        Assertions.assertThat(user.getPassword()).isEqualTo(userUpdate.getPassword());
+    }
+
+    @Test
+    @DisplayName("유저를 삭제한다.")
+    void 유저를_삭제한다() {
+        UserDeleteRequest udr = new UserDeleteRequest();
+        udr.setEmail(email);
+        udr.setPassword(newDummyPassword);
+        doReturn(true).when(passwordEncoder).matches(any(String.class), any(String.class));
+
+        userService.delete(udr);
+        Assertions.assertThat(userRepository.findByEmail(email)).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("유저를 검색한다.")
+    void 유저를_검색한다() {
+        User byEmail = userService.findByEmail(email);
+        Assertions.assertThat(byEmail.getEmail()).isEqualTo(email);
+    }
+}

--- a/user-service/src/test/java/com/example/userservice/util/certification/CertificationDigitHolderTest.java
+++ b/user-service/src/test/java/com/example/userservice/util/certification/CertificationDigitHolderTest.java
@@ -1,0 +1,18 @@
+package com.example.userservice.util.certification;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CertificationDigitHolderTest {
+
+    @Test
+    @DisplayName("암호 생성")
+    void 암호생성기() {
+        CertificationHolder certificationHolder = new CertificationDigitHolder();
+        Assertions.assertThat(certificationHolder.random().length()).isEqualTo(6);
+    }
+
+}


### PR DESCRIPTION
## 🐼 Summary (요약)

User certification 5자리 오류 해결

## 😼 Describe changes with intention (변경내용)

- 유저 이메일 인증을 위한 코드가 5자리로 출력되는 오류를 해결했습니다.
- 맨 앞자리가 0이여도 string으로 변환시키는 코드를 작성하였습니다.

## 🐶 Link Issue number (참고사항)

- close #70 
