### PR TITLE
[FIX] deleted된 recomment가 return되지 않도록 하기

### DIFF
--- a/board-service/src/main/java/org/example/boardservice/board/domain/Comment.java
+++ b/board-service/src/main/java/org/example/boardservice/board/domain/Comment.java
@@ -64,7 +64,7 @@ public class Comment {
     }
 
     public void addLike(String userId, String commentId, UuidHolder uuidHolder, ClockHolder clockHolder) {
-        log.info(this.toString());
+
         for(Like like : likes) {
             if(like.getUserId().equals(userId)){
                 throw new GlobalException(ResultCode.USER_STAR_ALREADY_EXISTS);
@@ -93,6 +93,10 @@ public class Comment {
             }
         }
         throw new GlobalException(ResultCode.COMMENT_NOT_FOUND);
+    }
+
+    public void removeDeletedRecomment() {
+        this.recomments.removeIf(Recomment::isDeleted);
     }
 
 }

--- a/board-service/src/main/java/org/example/boardservice/board/service/CommentServiceImpl.java
+++ b/board-service/src/main/java/org/example/boardservice/board/service/CommentServiceImpl.java
@@ -14,6 +14,7 @@ import org.example.boardservice.utils.UuidHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -30,6 +31,7 @@ public class CommentServiceImpl implements CommentService{
         Comment comment = Comment.create(cr,uuidHolder, clockHolder);
 
         List<Comment> comments = commentReposotiry.saveComment(comment);
+
         Board board = boardRepository.findByBoardId(cr.getBoardId());
         return new BoardResponse(board, comments);
     }


### PR DESCRIPTION
## 🐼 Summary (요약)

deleted된 recomment가 return되지 않도록 하기

## 😼 Describe changes with intention (변경내용)

- comment domain에 deleted된 recomment를 삭제하는 로직을 추가하였습니다.
- 차후 one to many관계를 해제하고, query를 통하여 recomment를 호출하지 않도록 방지하는 로직을 추가하면 좋을 것 같습니다.

## 🐶 Link Issue number (참고사항)

- close #116
