### PR TITLE
[FIX] board service recomment api 오류 해결하기

### DIFF
--- a/board-service/src/main/java/org/example/boardservice/board/dto/request/board/BoardLikeRequest.java
+++ b/board-service/src/main/java/org/example/boardservice/board/dto/request/board/BoardLikeRequest.java
@@ -3,14 +3,12 @@ package org.example.boardservice.board.dto.request.board;
 import lombok.*;
 
 @Getter
-
+@NoArgsConstructor
 public class BoardLikeRequest {
     private String userId;
-    private String postId;
 
     @Builder
-    public BoardLikeRequest(String userId, String postId) {
+    public BoardLikeRequest(String userId) {
         this.userId = userId;
-        this.postId = postId;
     }
 }

--- a/board-service/src/main/java/org/example/boardservice/board/service/comment/CommentServiceImpl.java
+++ b/board-service/src/main/java/org/example/boardservice/board/service/comment/CommentServiceImpl.java
@@ -63,7 +63,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public Recomment deleteRecomment(RecommentDeleteRequest recommentDeleteRequest) {
-        Comment comment = commentReposotiry.findById(recommentDeleteRequest.getRecommentId());
+        Comment comment = commentReposotiry.findById(recommentDeleteRequest.getCommentId());
         comment.deleteRecomment(recommentDeleteRequest.getRecommentId(), clockHolder);
 
         commentReposotiry.saveComment(comment);

--- a/board-service/src/test/java/org/example/boardservice/board/service/BoardServiceTest.java
+++ b/board-service/src/test/java/org/example/boardservice/board/service/BoardServiceTest.java
@@ -131,7 +131,6 @@ public class BoardServiceTest {
     public void 게시판_좋아요_추가(){
         BoardLikeRequest rq = BoardLikeRequest.builder()
                 .userId("user2")
-                .postId("board1")
                 .build();
 
         Board board = boardService.addLikeBoard("board1",rq);
@@ -143,7 +142,6 @@ public class BoardServiceTest {
     public void 게시판_좋아요_삭제(){
         BoardLikeRequest rq = BoardLikeRequest.builder()
                 .userId("user1")
-                .postId("board1")
                 .build();
 
         Board board = boardService.removeLikeBoard("board1",rq);


### PR DESCRIPTION
## 🐼 Summary (요약)

board service recomment api 오류 해결하기

## 😼 Describe changes with intention (변경내용)

- board service 중 comment를 찾는 곳에 recommentId가 들어가서 오류가 발생함을 확인하여 수정했습니다.
- board controller 중 board like에 필요없는 request가 있어 삭제했습니다. 

## 🐶 Link Issue number (참고사항)

- close #149 
