### PR TITLE
[FEAT] Sticky Session 을 통한 Local cache 동기화 적용

### DIFF
--- a/apigateway-service/src/main/java/org/example/apigatewayservice/filter/StickySessionFilter.java
+++ b/apigateway-service/src/main/java/org/example/apigatewayservice/filter/StickySessionFilter.java
@@ -1,22 +1,66 @@
 package org.example.apigatewayservice.filter;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
-//
-//public class StickySessionFilter extends AbstractGatewayFilterFactory<StickySessionFilter.Config> {
-//    public StickySessionFilter() {
-//        super(Config.class);
-//    }
-//
-//
-//    @Override
-//    public GatewayFilter apply(Config config) {
-//        return (exchange, chain) -> {
-//
-//        }
-//    }
-//
-//    public class
-//    Config {
-//    }
-//}
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+
+@Slf4j
+@Component
+public class StickySessionFilter extends AbstractGatewayFilterFactory<StickySessionFilter.Config> {
+
+    private final DiscoveryClient discoveryClient;
+    public StickySessionFilter(DiscoveryClient discoveryClient) {
+        super(Config.class);
+        this.discoveryClient = discoveryClient;
+    }
+
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+            String portCookieValue = Optional.ofNullable(request.getCookies().getFirst("server-port"))
+                    .map(cookie -> cookie.getValue())
+                    .orElse(null);
+            log.info(portCookieValue);
+
+            if (portCookieValue != null) {
+                String serviceId = "USER-SERVICE";  // 서비스 ID
+                List<ServiceInstance> instances = discoveryClient.getInstances(serviceId);
+
+                // 포트에 맞는 인스턴스 선택
+                Optional<ServiceInstance> instanceOpt = instances.stream()
+                        .peek(instance -> System.out.println("Instance Port: " + instance.getPort()))  // 포트 번호 출력
+                        .filter(instance -> String.valueOf(instance.getPort()).equals(portCookieValue))
+                        .findFirst();
+
+
+                if (instanceOpt.isPresent()) {
+                    URI newUri = URI.create(instanceOpt.get().getUri().toString() + request.getURI().getRawPath());
+                    ServerHttpRequest newRequest = request.mutate().uri(newUri).build();
+                    ServerWebExchange newExchange = exchange.mutate().request(newRequest).build();
+                    return chain.filter(newExchange);
+                }else{
+                    log.info("NOT EXIST");
+                }
+            }
+
+            return chain.filter(exchange);
+        };
+    }
+
+    public static class Config {
+        // Put the configuration properties here
+    }
+}

--- a/apigateway-service/src/main/resources/application.yaml
+++ b/apigateway-service/src/main/resources/application.yaml
@@ -27,6 +27,7 @@ spring:
             - Method=GET,POST
           filters:
             - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+            - StickySessionFilter
         - id: user-join-service
           uri: lb://USER-SERVICE
           predicates:

--- a/user-service/src/main/java/com/example/userservice/user/service/user/UserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/user/service/user/UserServiceImpl.java
@@ -62,11 +62,13 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserWithToken login(UserLoginRequest userLogin) {
 
+        System.out.println("HI3");
         User user = userRepository.findByEmail(userLogin.getEmail()).orElseThrow(
                 () -> new GlobalException(ErrorCode.LOGIN_ERROR)
         );
-
+        System.out.println("HI");
         if (!passwordEncoder.matches(userLogin.getPassword(), user.getPassword())) {
+            System.out.println("HI2");
             throw new GlobalException(ErrorCode.WRONG_USER_PASSWORD);
         } else {
             String accessToken = jwtTokenService.accessToken(user);


### PR DESCRIPTION
## 🐼 Summary (요약)

- Sticky Session Handler을 이용해서, User-service의 여러 인스턴스 중에 사용자의 코드가 저장되어있는 인스턴스에

연결을 가능하도록 만들었습니다. 

## 😼 Describe changes with intention (변경내용)

1. 사용자가 학교메일을 통해서 인증을 받는다 -> 인증코드가 인스턴스의 local cache에 저장되고 동시에, 사용자 cookie에 인스턴스의 port정보 기입
2. 사용자가 인증코드를 post 요청으로 보내서 인증을 받는다 -> 인증이 성공되면 사용자의 cookie의 port정보 삭제

api-gateway에서 사용자 cookie의 port를 확인하고 해당 port와 일치하는 Instance에게 라우팅을 해줍니다. 만약 cookie가 없다면 RR방식으로 routing을 해줍니다. 

## 🐶 Link Issue number (참고사항)

- close #103 
