### PR TITLE
[FEAT] User 가입 시 인증 6자리 코드를 직접 입력하도록 변경한다.

### DIFF
--- a/user-service/src/main/java/com/example/userservice/user/controller/user/UserCreateController.java
+++ b/user-service/src/main/java/com/example/userservice/user/controller/user/UserCreateController.java
@@ -52,17 +52,17 @@ public class UserCreateController {
         return of(SuccessCode.EMAIL_CREATED, userJoin);
     }
 
-//    // verify certification code after user create
-//    // 방식 1 번호 입력
-//    @PostMapping("/certification")
-//    public ResponseEntity<GlobalResponse<UserJoinResponse>> certificationByCode(
-//            @RequestBody UserJoinCertificationRequest joinUserCertification
-//    ){
-//        new RequestCheck(joinUserCertification).check();
-//
-//        UserJoin userJoin = joinUserService.certification(joinUserCertification);
-//        return of(SuccessCode.EMAIL_VERIFIED, UserJoinResponse.from(userJoin));
-//    }
+    // verify certification code after user create
+    // 방식 1 번호 입력
+    @PostMapping("/certification")
+    public ResponseEntity<GlobalResponse<UserJoinResponse>> certificationByCode(
+            @RequestBody UserJoinCertificationRequest joinUserCertification
+    ){
+        new RequestCheck(joinUserCertification).check();
+
+        UserJoin userJoin = joinUserService.certification(joinUserCertification);
+        return of(SuccessCode.EMAIL_VERIFIED, UserJoinResponse.from(userJoin));
+    }
 
     // 방식 2 링크
     // String으로 인증 정보 반환 : 수정 가능

--- a/user-service/src/main/java/com/example/userservice/user/service/user/join/JoinUserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/user/service/user/join/JoinUserServiceImpl.java
@@ -54,17 +54,19 @@ public class JoinUserServiceImpl implements JoinUserService {
     }
 
     @Override
-    public UserJoin certification(UserJoinCertificationRequest joinUserCertification) {
+    public UserJoin certification(UserJoinCertificationRequest joinUserCertification){
         UserJoin userJoin = joinUserRepository.findByEmail(joinUserCertification.getEmail()).orElseThrow(
                 () -> new GlobalException(ErrorCode.USER_NOT_FOUND_EMAIL)
         );
         // 보안코드가 맞는지 확인
         boolean compareResult = compare(userJoin.getCertificationCode(), joinUserCertification.getCertificationCode());
+
         if (compareResult) {
             userJoin = userJoin.updateStatus(userJoin, UserStatus.ABLE);
             joinUserRepository.replace(userJoin.getEmail(), userJoin);
             return userJoin;
         }
+
         throw new GlobalException(ErrorCode.USER_CERTIFICATION_NOT_MATCHED);
     }
 

--- a/user-service/src/test/java/com/example/userservice/user/service/user/join/JoinUserServiceImplTest.java
+++ b/user-service/src/test/java/com/example/userservice/user/service/user/join/JoinUserServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.example.userservice.user.service.user.join;
+
+import com.example.userservice.user.domain.user.UserJoin;
+import com.example.userservice.user.domain.user.value.School;
+import com.example.userservice.user.domain.user.value.UserStatus;
+import com.example.userservice.user.dto.request.user.UserJoinCertificationRequest;
+import com.example.userservice.user.infrastructure.user.UserRepository;
+import com.example.userservice.user.infrastructure.user.join.JoinUserRepository;
+import com.example.userservice.user.mock.FakeUserDigitRepository;
+import com.example.userservice.user.service.user.mail.UserCertificationService;
+import com.example.userservice.util.certification.CertificationHolder;
+import com.example.userservice.util.certification.email.EmailCertification;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JoinUserServiceImplTest {
+
+    private JoinUserService joinUserService;
+    private JoinUserRepository joinUserRepository;
+    private CertificationHolder certificationHolder;
+    private UserCertificationService userCertificationService;
+    private EmailCertification emailCertification;
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void init() {
+        joinUserRepository = new FakeUserDigitRepository();
+        joinUserService = new JoinUserServiceImpl(
+                certificationHolder, joinUserRepository, userCertificationService, emailCertification, userRepository
+        );
+    }
+
+    @Test
+    void 이메일6자리코드로인증하기() {
+        // given
+        UserJoinCertificationRequest userJoinCertificationRequest = new UserJoinCertificationRequest("test", "333333");
+        UserJoin beforeJoinMock = new UserJoin("test", School.KAIST, "333333", UserStatus.PENDING);
+        joinUserRepository.save(beforeJoinMock);
+
+        // when
+        UserJoin afterJoinMock = joinUserService.certification(userJoinCertificationRequest);
+
+        // then
+        Assertions.assertThat(afterJoinMock.getStatus()).isEqualTo(UserStatus.ABLE);
+        Assertions.assertThat(afterJoinMock.getEmail()).isEqualTo("test");
+    }
+
+    @Test
+    void 유효한email이없다() {
+        UserJoinCertificationRequest userJoinCertificationRequest = new UserJoinCertificationRequest("exception", "333333");
+        UserJoin beforeJoinMock = new UserJoin("test", School.KAIST, "333333", UserStatus.PENDING);
+        joinUserRepository.save(beforeJoinMock);
+
+
+        Assertions.assertThatThrownBy(() -> joinUserService.certification(userJoinCertificationRequest)).isInstanceOf(RuntimeException.class);
+    }
+
+
+}


### PR DESCRIPTION
## 🐼 Summary (요약)

User 가입 시 인증 6자리 코드를 직접 입력하도록 변경한다.

## 😼 Describe changes with intention (변경내용)

- 기존 email에서 링크를 타고 들어가여 인증하는 방식에서, 직접 6자리 코드를 입력하는 방식으로 변경하였습니다.
- 또한 FakeUserJoinDigitReposioty를 활용하여 UserJoinService의 test를 구현하였습니다.
- 생성된 api는 노션에 추가하였습니다.

## 🐶 Link Issue number (참고사항)

- #155 
